### PR TITLE
feat: limit token units length

### DIFF
--- a/packages/nextjs/components/viem/BalanceOfTokens.tsx
+++ b/packages/nextjs/components/viem/BalanceOfTokens.tsx
@@ -1,10 +1,10 @@
 import { useContext } from "react";
-import { formatUnits } from "viem";
 import { useContractRead } from "wagmi";
 import * as chains from "wagmi/chains";
 import TokenIcon from "~~/components/svg/TokenIcon";
 import { ContractContext } from "~~/context";
 import deployedContracts from "~~/contracts/deployedContracts";
+import formatUnits from "~~/utils/formatUnits";
 
 export default function BalanceOfTokens({ address }: { address: `0x${string}` }) {
   const contractContext = useContext(ContractContext);
@@ -46,6 +46,5 @@ function Balance({
     args: [address],
     watch: true,
   });
-  const formattedData = data ? formatUnits(data, decimals) : 0;
-  return <>{formattedData}</>;
+  return <>{data ? formatUnits(data, decimals, 5) : 0}</>;
 }

--- a/packages/nextjs/components/viem/ContractInfo.tsx
+++ b/packages/nextjs/components/viem/ContractInfo.tsx
@@ -4,12 +4,13 @@ import EthIcon from "../svg/EthIcon";
 import BalanceOfTokens from "./BalanceOfTokens";
 import { blo } from "blo";
 import { twMerge } from "tailwind-merge";
-import { formatEther, formatUnits } from "viem";
+import { formatEther } from "viem";
 import { useAccount, useBalance, useContractRead } from "wagmi";
 import * as chains from "wagmi/chains";
 import { CurrencyDollarIcon, TrophyIcon } from "@heroicons/react/24/outline";
 import { ContractContext } from "~~/context";
 import deployedContracts from "~~/contracts/deployedContracts";
+import formatUnits from "~~/utils/formatUnits";
 
 export default function ContractInfo({ className }: { className?: string }) {
   const account = useAccount();
@@ -39,7 +40,7 @@ export default function ContractInfo({ className }: { className?: string }) {
   if (!account.address) return null;
 
   if (contractContext.betPrice) {
-    tokenPrice = formatUnits(contractContext.betPrice, contractContext.tokenDecimals || 0);
+    tokenPrice = formatUnits(contractContext.betPrice, contractContext.tokenDecimals || 0, 5);
   }
 
   return (
@@ -84,7 +85,7 @@ export default function ContractInfo({ className }: { className?: string }) {
           </div>
           <div className="stat-title">Price pool</div>
           <div className="stat-value text-warning">
-            {prizePool && typeof tokenDecimals !== "undefined" ? formatUnits(prizePool, tokenDecimals) : 0}
+            {prizePool && typeof tokenDecimals !== "undefined" ? formatUnits(prizePool, tokenDecimals, 5) : 0}
           </div>
           <div className="stat-desc">Total prize pool</div>
         </div>

--- a/packages/nextjs/components/viem/PurchaseTokens.tsx
+++ b/packages/nextjs/components/viem/PurchaseTokens.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useContext, useState } from "react";
 import TransactionList from "./TransactionList";
 import { twMerge } from "tailwind-merge";
-import { formatUnits, parseEther, parseUnits } from "viem";
+import { parseEther, parseUnits } from "viem";
 import { useContractWrite } from "wagmi";
 import * as chains from "wagmi/chains";
 import ErrorBlock from "~~/components/Error";
 import { ContractContext } from "~~/context";
 import deployedContracts from "~~/contracts/deployedContracts";
+import formatUnits from "~~/utils/formatUnits";
 
 export default function PurchaseTokens({ className }: { className?: string }) {
   const [amount, setAmount] = useState<string>("");
@@ -92,8 +93,8 @@ export default function PurchaseTokens({ className }: { className?: string }) {
           {amount && contractContext.purchaseRatio ? (
             <div className="text-neutral-500 text-sm my-3">
               It costs{" "}
-              {formatUnits(getEthAmount(amount, contractContext.purchaseRatio), contractContext.tokenDecimals || 0)} SEP
-              to buy
+              {formatUnits(getEthAmount(amount, contractContext.purchaseRatio), contractContext.tokenDecimals || 0, 5)}{" "}
+              SEP to buy
             </div>
           ) : null}
           <div>

--- a/packages/nextjs/utils/formatUnits.ts
+++ b/packages/nextjs/utils/formatUnits.ts
@@ -1,0 +1,39 @@
+import type { ErrorType } from "viem/errors/utils.js";
+
+export type FormatUnitsErrorType = ErrorType;
+
+/**
+ * Improved version of viem formatUnits function.
+ * https://github.com/wevm/viem/blob/d2f93e726df1ab1ff86098d68a4406f6fae315b8/src/utils/unit/formatUnits.ts
+ *
+ * Allow to limit amount of zeros after the decimal point.
+ * !Doesn't implement proper rounding.
+ *
+ * @example
+ * limit = 3
+ * formatUnits(1000000000000000000n, 18) // '1.0'
+ * formatUnits(1000000100000000000n, 18) // '1.0000001'
+ * formatUnits(1001713200000000000n, 18) // '1.001' - no proper rounding
+ */
+export default function formatUnits(value: bigint, decimals: number, limit = 0) {
+  let display = value.toString();
+
+  const negative = display.startsWith("-");
+  if (negative) display = display.slice(1);
+
+  display = display.padStart(decimals, "0");
+  // eslint-disable-next-line prefer-const
+  let [integer, fraction] = [display.slice(0, display.length - decimals), display.slice(display.length - decimals)];
+  fraction = fraction.replace(/(0+)$/, "");
+
+  let firstNonZero = 0;
+  for (let i = 0; i < fraction.length; i++) {
+    if (fraction[i] !== "0") {
+      firstNonZero = i;
+      break;
+    }
+  }
+
+  limit = Math.max(limit, firstNonZero + 1);
+  return `${negative ? "-" : ""}${integer || "0"}${fraction ? `.${fraction.slice(0, limit)}` : ""}`;
+}


### PR DESCRIPTION
Avoid showing long numbers
```code
 * limit = 3
 * formatUnits(1000000000000000000n, 18) // '1.0'
 * formatUnits(1000000100000000000n, 18) // '1.0000001'
 * formatUnits(1001713200000000000n, 18) // '1.001' - no proper rounding
```